### PR TITLE
Update SNVPhyl tool suite

### DIFF
--- a/tools/suite_snvphyl/.shed.yml
+++ b/tools/suite_snvphyl/.shed.yml
@@ -1,5 +1,5 @@
 categories: [Sequence Analysis]
 description: SNVPhyl suite defining all dependencies for SNVPhyl
-name: suite_snvphyl_1_1_0
+name: suite_snvphyl_1_2_0
 owner: nml
 remote_repository_url: https://github.com/phac-nml/snvphyl-galaxy


### PR DESCRIPTION
Updates the SNVPhyl tool suite. Done like this (as separate PR) so that all tools get uploaded into the Galaxy toolshed first before the tool suite is updated.